### PR TITLE
글작성시 편의성을 위한 RichTextEditor 수정

### DIFF
--- a/app/components/PostWrite.css
+++ b/app/components/PostWrite.css
@@ -157,6 +157,17 @@
   border-bottom: 1px solid #000000;
 }
 
+.ql-container.ql-snow {
+  overflow-y: auto;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.ql-editor img {
+  max-width: 60% !important;
+  height: auto !important;
+}
+
 .button-container {
   width: 95%;
 

--- a/app/components/RichTextEditor.tsx
+++ b/app/components/RichTextEditor.tsx
@@ -20,7 +20,7 @@ export default function RichTextEditorComponent() {
             ["bold", "italic", "underline", "strike"],
             ["image"],
             [{ list: "ordered" }, { list: "bullet" }],
-            [{ size: ["small", false, "large", "huge"] }],
+            [{ 'align': [] }, { size: ["small", false, "large", "huge"] }],
             [{ color: [] }, { background: [] }],
           ],
         },
@@ -47,7 +47,7 @@ export default function RichTextEditorComponent() {
 
   return (
     <>
-      <div ref={editorRef} style={{ height: "200px" }} />
+      <div ref={editorRef} style={{ height: "400px" }} />
     </>
   );
 }


### PR DESCRIPTION
* quillEditor toolbar에 align 정렬 추가

* 기존에 사진을 불러왔을 때 크기가 가로에 맞춰 꽉참
  -> max-width 설정하여 조정

* Editor 내부에서 내용이 늘어날 때 아래로 무한정 길어지는 이슈
  -> Editor 콘테이너 내부에 overflow 추가하여 스크롤 생성